### PR TITLE
Change definition of $debugBoolean so that it uses matches(), allows for

### DIFF
--- a/xsl/dita-support-lib.xsl
+++ b/xsl/dita-support-lib.xsl
@@ -35,7 +35,9 @@
   <xsl:key name="topicsById" match="*[df:class(., 'topic/topic')]" use="@id"/>
 
   <xsl:param name="debug" select="'false'"/>
-  <xsl:variable name="debugBoolean" select="if ($debug = 'true') then true() else false()" as="xs:boolean"/>
+  <xsl:variable name="debugBoolean" 
+    select="matches($debug,'true|1|on|yes', 'i')" as="xs:boolean"
+  />
 
   <!-- List of base types that are inherently blocks. Include %basic.block as
        well as other elements that are also normally or always presented as


### PR DESCRIPTION
additional values to resolve to true(), and is consistent with how other D4P and
d-c projects define $debugBoolean. Closes #8